### PR TITLE
Prepare for crate.io release v0.1.0

### DIFF
--- a/iommufd-bindings/CHANGELOG.md
+++ b/iommufd-bindings/CHANGELOG.md
@@ -1,0 +1,17 @@
+## Upcoming release
+
+## Changed
+
+## Added
+
+## Fixed
+
+
+# [v0.1.0]
+
+This is the first `iommufd-bindings` crate release.
+
+This crate provides Rust FFI bindings to iommufd uAPIs, generated using
+[bindgen](https://crates.io/crates/bindgen). Currently, the bindings are
+generated using bindgen version 0.72.0 and kernel version
+[v6.6](https://github.com/torvalds/linux/tree/v6.6).

--- a/iommufd-ioctls/CHANGELOG.md
+++ b/iommufd-ioctls/CHANGELOG.md
@@ -1,0 +1,18 @@
+## Upcoming release
+
+## Changed
+
+## Added
+
+## Fixed
+
+
+# [v0.1.0]
+
+This is the first `iommufd-ioctls` crate release.
+
+The iommufd-ioctls crate provides safe wrappers over the
+[IOMMUFD uAPIs](https://docs.kernel.org/userspace-api/iommufd.html#iommufd-user-api), a set
+of ioctls used to control the IOMMU subsystem as it relates to managing
+IO page tables from userspace. The ioctls are accessible through
+structure `IommuFd`.

--- a/iommufd-ioctls/Cargo.toml
+++ b/iommufd-ioctls/Cargo.toml
@@ -12,4 +12,4 @@ keywords = ["iommufd"]
 [dependencies]
 iommufd-bindings = { version = "0.1.0", path = "../iommufd-bindings" }
 thiserror = "2.0.17"
-vmm-sys-util = { version = "0.14.0" }
+vmm-sys-util = { version = "0.15.0" }


### PR DESCRIPTION
This is required for vfio crates releases. See https://github.com/rust-vmm/vfio/issues/136.